### PR TITLE
Modify dispatch

### DIFF
--- a/components/index/ListStudents.vue
+++ b/components/index/ListStudents.vue
@@ -52,11 +52,6 @@
 export default {
   computed: {
     Students() {
-      this.$store.state.students.forEach((student, index) => {
-        if (!student.schedule) {
-          this.$store.commit('setArray', index)
-        }
-      })
       return this.$store.state.students
     },
     Calendar() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,11 +17,12 @@ export default {
       dark: true,
     }
   },
-  created() {
+  beforeCreate() {
     this.$store.dispatch('getRelease')
     this.$store.dispatch('getStudents')
     this.$store.dispatch('getCalendar')
     this.$store.dispatch('getWeather')
+    this.$forceUpdate()
   },
   mounted() {
     if (


### PR DESCRIPTION
#101 
- 前回の変更は直接的に解決に繋がっていなかったので、再度直してみました
- computedがオブジェクトや配列の変更を検知しないとのことだったので、
1. createdをbeforeCreateに変更することで、そもそもリアクティブデータが初期化される前にdispatchを行っています
2. $forceUpdateを行うことで、強制的に仮想DOMの更新を行っています
（参照：https://it-web-life.com/vue_object_not_updated/）

1と2はどちらかが聞けばいいなという感じなので、上手くいけばどちらかを削除で良いのかなと！

- 他一つの変更は、冗長な処理を行なっていたので消してます